### PR TITLE
Remove possible panic on remove_prefix

### DIFF
--- a/src/parse.rs
+++ b/src/parse.rs
@@ -41,8 +41,8 @@ fn remove_prefix(data: &'_ str) -> Result<&'_ str, ParseError> {
     }
 
     // check HC1: header
-    if &data[0..4] != "HC1:" {
-        return Err(ParseError::InvalidPrefix(String::from(&data[0..3])));
+    if !data.starts_with("HC1:") {
+        return Err(ParseError::InvalidPrefix(data.chars().take(4).collect()));
     }
 
     Ok(&data[4..])


### PR DESCRIPTION
Accessing a `str` through a rage index may cause panic if the string contains multibyte `char`s.
Another solution would be to do `data.as_bytes()[0..4] != b"HC1:"`, because by considering them as raw bytes no panic can occur.